### PR TITLE
Follow HTTP Redirects

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -176,15 +176,34 @@ Request.prototype.makeSecureRequest = function (url, httpMethod, data,
 Request.prototype.makeRequest = function (url, httpMethod, data, callback) {
 	var apiRequest, headers, prop, self = this;
 
-	data = this.prepare(data);
-	if (httpMethod === 'GET') {
-		url = url + '?' + querystring.stringify(data);
+	// When data is false, we don't want any params/data
+	if (data !== false)
+	{
+		data = this.prepare(data);
+		if (httpMethod === 'GET') {
+			url = url + '?' + querystring.stringify(data);
+		}
 	}
 
 	this.logger.info(httpMethod + ': ' + url);
 	apiRequest = this.client.request(httpMethod, url, this.createHeaders());
 
 	apiRequest.on('response', function handleResponse(response) {
+
+		// If we are getting a redirect order
+		if (response.statusCode == '302')
+		{
+			self.logger.info("Redirecting to: " + response.headers.location);
+			return self.makeRequest(response.headers.location, httpMethod, false, callback);
+		}
+
+		// We only want xml/json
+		if (response.headers['content-type'] == 'audio/mpeg')
+		{
+			self.logger.error("We hit some data/audio. Aborting...");
+			return;
+		}
+
 		var responseBuffer = '';
 
 		response.setEncoding("utf8");


### PR DESCRIPTION
What changed:
- If we get the 302 status code we should follow to the new location.
- When redirecting we must drop the user params/data since the API handles this for us.
- If the result is some data (like audio/mpeg) we should abort. (Since file handling is not implemented)
