### PR TITLE
Add card types to schema

### DIFF
--- a/assets/7digital-api-schema.json
+++ b/assets/7digital-api-schema.json
@@ -179,6 +179,17 @@
 					"methodName": "getReleaseIdByUrl"
 				}
 			]
+		},
+		"Payment":
+			{
+			"resource": "payment",
+			"actions":
+			[
+				{
+					"apiCall": "card/type",
+					"methodName": "getCardTypes"
+				}
+			]
 		}
 	}
 }

--- a/lib/responseparser.js
+++ b/lib/responseparser.js
@@ -24,7 +24,8 @@ function normaliseResourceArrays(response) {
 			'searchResults.searchResult',
 			'recommendations.recommendedItem',
 			'tags.tag',
-			'taggedResults.taggedItem' //
+			'taggedResults.taggedItem',
+			'cardTypes.cardType'
 		]).each(function checkLength(item) {
 			var parts = item.split('.'),
 				parent = parts[0],
@@ -69,6 +70,35 @@ function normaliseResourceArrays(response) {
 	return response;
 }
 
+function renameTextNodes(response) {
+	underscore({
+		'cardTypes.cardType' : 'name'
+	}).each(function renameTextNode(name, item) {
+		var parts = item.split('.'),
+			parent = parts[0],
+			child = parts[1];
+
+		//text nodes are given the key '_' if there are attributes present on the node
+		function doRename(obj) {
+			obj[name] = obj._;
+			delete obj._;
+		}
+
+		if (response[parent] && response[parent][child]) {
+
+			var node = response[parent][child];
+			if (node.length !== undefined) {
+				underscore(node).each(function (subNode) { doRename(subNode); });
+			} else {
+				doRename(node);
+			}
+
+		}
+	});
+
+	return response;
+}
+
 // Callback for parsing the XML response return from the API
 // and converting it to JSON and handing control back to the
 // caller.
@@ -104,8 +134,12 @@ function parse(response, opts, callback) {
 									result.response.status + '" from api'));
 			}
 			else {
-				var normalisedResult = normaliseResourceArrays(result.response);
-				callback(null, normalisedResult);
+				var clean = underscore.compose(
+					renameTextNodes,
+					normaliseResourceArrays);
+
+				var cleanedResult = clean(result.response);
+				callback(null, cleanedResult);
 			}
 		}
 	});

--- a/spec/responseparser_spec.js
+++ b/spec/responseparser_spec.js
@@ -93,4 +93,17 @@ describe('responseparser', function() {
 		response = callbackSpy.lastCall.args[1];
 		expect(response.basket.basketItems).to.be.instanceOf(Array);
 	});
+
+	it('should give the payment card text node a name', function () {
+		var callbackSpy = sinon.spy(),
+			xml = fs.readFileSync(path.join(__dirname +
+								"/responses/payment-card-type.xml"), "utf8");
+		parser.parse(xml, createOptsWithFormat('js'), callbackSpy);
+		expect(callbackSpy.calledOnce);
+
+		var response = callbackSpy.lastCall.args[1];
+		expect(response.cardTypes.cardType).to.be.instanceOf(Array);
+		expect(response.cardTypes.cardType[0].name).to.equal('Mastercard');
+		expect(response.cardTypes.cardType[0].id).to.equal('MASTERCARD');
+	});
 });

--- a/spec/responses/payment-card-type.xml
+++ b/spec/responses/payment-card-type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" status="ok" version="1.2" xsi:noNamespaceSchemaLocation="http://api.7digital.com/1.2/static/7digitalAPI.xsd">
+	<cardTypes>
+		<cardType id="MASTERCARD">Mastercard</cardType>
+	</cardTypes>
+</response>


### PR DESCRIPTION
Add payment/card/type endpoint to the schema, as per the c# wrapper (public in that project although undocumented on api.7digital.com).

Only slightly strange thing is the response has e.g.:

```
<cardTypes>
    <cardType id="MASTERCARD">Mastercard</cardType>
    <cardType id="MAESTRO">Maestro</cardType>
    ....
</cardTypes>
```

which means the JSON comes out like this - the underscore is a bit unclear maybe?

```
{ cardType: [
    { _: 'Maestro', id: 'MAESTRO' },
    { _: 'Mastercard', id: 'MASTERCARD' },
    .... 
]}
```
