### PR TITLE
Add support for 3-legged signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,14 @@ of the API endpoints and the parameters they accept.
 
 ## OAuth protected endpoints
 
-**NOTE: The oauth access method changed considerably in 0.19.0**
+**NOTE: The oauth access method changed considerably in 0.19.0, updating to
+the latest version is highly recommended**
 
-### Accessing previews
+### Accessing the media delivery api
 
-The preview endpoint behaves differently from the other endpoints as it returns
-you the bytes to to the clip.  It also resides on a different host.  You must
-sign your requests:
+The media delivery endpoints behave differently from the other endpoints as
+they return you the bytes to the content. You must sign all your requests like
+so:
 
 ```javascript
 var api = require('7digital-api').configure({
@@ -114,6 +115,17 @@ var api = require('7digital-api').configure({
 
 var oauth = new api.OAuth();
 var previewUrl = oauth.sign('http://previews/7digital.com/clip/12345');
+
+// For access to locker / subscription streaming without managed users you
+// will need to provide the accesstoken and secret for the user
+var signedUrl = oauth.sign('https://stream.svc.7digital.net/stream/locker', {
+	trackId: 1234,
+	formatId: 26,
+	accesstoken: 'ACCESS_TOKEN',
+	accesssecret: 'ACCESS_SECRET'
+});
+// Requesting this URL will now respond with the media data (or redirect to
+// an error).
 ```
 
 ### Making requests on behalf of a user to OAuth protected endpoints

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var qs = require('querystring');
+var _ = require('lodash');
 var OAuthClient = require('oauth').OAuth;
 var accessTokenUrl = 'http://api.7digital.com/1.2/oauth/accesstoken';
 var responseParser = require('./responseparser');
@@ -206,34 +207,32 @@ OAuth.prototype.getAccessToken = function getAccessToken(requestData,
    }
 };
 
-// Allows you to sign 2-legged GET requests manually.  The common case for this
-// is to sign preview clip requests which are on a different host from the rest
-// of the API.
+// Allows you to sign GET requests manually.  The common case for this
+// is to access the media delivery API where you make a signed request
+// and receive the media data directly in the reponse.
 //
 //  - @param {String} `url` The url to sign
-//  - @param {Object} `parameters` Any extra parameters.
+//  - @param {Object} `parameters` Any query parameters.
 OAuth.prototype.sign = function sign(url, parameters) {
-	var orderedParams;
-	var params = {};
+	var orderedParams, accesstoken, accesssecret;
 	var query = '';
-	var parsedUrl= require('url').parse( url, false );
+	var parsedUrl = require('url').parse(url, false);
 
-	if (this.defaultParams.country) {
-		params.country = this.defaultParams.country;
-	}
+	_.defaults(parameters, this.defaultParams);
 
-	if (parameters && parameters.country) {
-		params.country = parameters.country;
-	}
+	accesstoken = parameters.accesstoken || null;
+	delete parameters.accesstoken;
+	accesssecret = parameters.accesssecret || null;
+	delete parameters.accesssecret;
 
-	orderedParams = this.client._prepareParameters(null, null,
-		'GET', url, params);
+	orderedParams = this.client._prepareParameters(accesstoken, accesssecret,
+		'GET', url, parameters);
 
-	for( var i= 0 ; i < orderedParams.length; i++) {
-		query+= orderedParams[i][0] + '=' +
+	for (var i = 0; i < orderedParams.length; i++) {
+		query += orderedParams[i][0] + '=' +
 			this.client._encodeData(orderedParams[i][1]) + '&';
 	}
-	query= query.substring(0, query.length-1);
+	query = query.substring(0, query.length - 1);
 
 	return parsedUrl.protocol + '//'+ parsedUrl.host + parsedUrl.pathname +
 		'?' + query;

--- a/test-integration/oauth-test.js
+++ b/test-integration/oauth-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assert = require('chai').assert;
+var https = require('https');
 
 function die(msg) {
 	throw new Error(msg);
@@ -116,6 +117,24 @@ describe('api when oauth is required', function () {
 			assert.notOk(err, 'unexpected error: ' + errMsg);
 			done();
 		});
-
 	});
+
+	it('signs 3-legged locker stream urls', function (done) {
+		var oauth = new api.OAuth({
+			defaultParams: {
+				country: 'gb',
+				accesstoken: userToken,
+				accesssecret: userSecret
+			}
+		});
+		var signedUrl = oauth.sign(
+			'https://stream.svc.7digital.net/stream/locker',
+			{ trackId: 29286733, formatId: 26 });
+
+		https.get(signedUrl, function checkResponse(response) {
+			assert.equal(response.statusCode, 200);
+			done();
+		}).on('error', done);
+	});
+
 });


### PR DESCRIPTION
This enables 3-legged signing of media delivery requests and thus fixes issue #58.
