### PR TITLE
Handle null parse result caused by empty XML response

### DIFF
--- a/lib/responseparser.js
+++ b/lib/responseparser.js
@@ -80,13 +80,19 @@ function parse(response, opts, callback) {
 		var cleanedResult;
 		var clean, error;
 
+		function makeParseErr(msg) {
+			return new ApiParseError(msg + ' from: ' + opts.url, response);
+		}
+
 		// Unparsable response text
 		if (err) {
-			return callback(new ApiParseError(
-				'Unparsable api response from: ' + opts.url, response));
-		} else if (!result.response) {
-			return callback(new ApiParseError(
-				'Unexpected response status from: ' + opts.url, response));
+			return callback(makeParseErr('Unparsable api response'));
+		}
+		if (!result) {
+			return callback(makeParseErr('Empty response'));
+		}
+		if (!result.response) {
+			return callback(makeParseErr('Missing response node'));
 		}
 
 		// Reponse was a 7digital API error object

--- a/test/responseparser-test.js
+++ b/test/responseparser-test.js
@@ -49,6 +49,16 @@ describe('when parsing responses', function () {
 			'Unparsable api response from: /foo');
 	});
 
+	it('calls back with parse error when response is empty', function () {
+		var callbackSpy = sinon.spy();
+
+		parser.parse('', createOptsWithFormat('js'), callbackSpy);
+		assert(callbackSpy.calledOnce);
+		assert.instanceOf(callbackSpy.lastCall.args[0], ApiParseError);
+		assert.strictEqual(callbackSpy.lastCall.args[0].message,
+			'Empty response from: /foo');
+	});
+
 	it('calls back with the error when the status is error', function () {
 		var error, response, callbackSpy = sinon.spy();
 		var xml = fs.readFileSync(


### PR DESCRIPTION
This should fix `TypeError: Cannot read property 'response' of null`